### PR TITLE
add Discord and GitHub Auth Providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,9 +17,9 @@ DATABASE_URL="mysql://root:password@localhost:3306/freepass"
 # You can generate a new secret on the command line with:
 # openssl rand -base64 32
 # https://next-auth.js.org/configuration/options#secret
-# NEXTAUTH_SECRET=""
+NEXTAUTH_SECRET=""
 NEXTAUTH_URL="http://localhost:3000"
 
-# Next Auth Discord Provider
-DISCORD_CLIENT_ID=""
-DISCORD_CLIENT_SECRET=""
+# GitHub Provider
+GITHUB_ID=""
+GITHUB_SECRET=""

--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@ DATABASE_URL="mysql://root:password@localhost:3306/freepass"
 NEXTAUTH_SECRET=""
 NEXTAUTH_URL="http://localhost:3000"
 
+# Discord Provider
+DISCORD_CLIENT_ID=""
+DISCORD_CLIENT_SECRET=""
+
 # GitHub Provider
 GITHUB_ID=""
 GITHUB_SECRET=""

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Now you need to generate a secret for NextAuth. Run:
 openssl rand -base64 32
 ```
 
-You can then set the value of `NEXTAUTH_SECRET` to the output.
+You can then set the value of `NEXTAUTH_SECRET` to the output. 
+
+You will also need to set the `GITHUB_ID` and `GITHUB_SECRET` so that you can sign in via GitHub locally. See @paul-macfarlane for getting access to these.
 
 Next, run a prisma migration to update your local database's schema:
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ openssl rand -base64 32
 
 You can then set the value of `NEXTAUTH_SECRET` to the output. 
 
-You will also need to set the `GITHUB_ID` and `GITHUB_SECRET` so that you can sign in via GitHub locally. See @paul-macfarlane for getting access to these.
+You will also need to set the `GITHUB_ID` and `GITHUB_SECRET` so that you can sign in via GitHub locally. Similarly, to sign in locally via Discord, you will need to set `DISCORD_CLIENT_ID` and `DISCORD_CLIENT_SECRET`. See @paul-macfarlane for getting access to these.
 
 Next, run a prisma migration to update your local database's schema:
 

--- a/prisma/migrations/20230704125812_/migration.sql
+++ b/prisma/migrations/20230704125812_/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Account` ADD COLUMN `refresh_token_expires_in` INTEGER NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,19 +18,20 @@ model Example {
 
 // Necessary for Next auth
 model Account {
-    id                String  @id @default(cuid())
-    userId            String
-    type              String
-    provider          String
-    providerAccountId String
-    refresh_token     String? @db.Text
-    access_token      String? @db.Text
-    expires_at        Int?
-    token_type        String?
-    scope             String?
-    id_token          String? @db.Text
-    session_state     String?
-    user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+    id                       String  @id @default(cuid())
+    userId                   String
+    type                     String
+    provider                 String
+    providerAccountId        String
+    refresh_token            String? @db.Text
+    refresh_token_expires_in Int?
+    access_token             String? @db.Text
+    expires_at               Int?
+    token_type               String?
+    scope                    String?
+    id_token                 String? @db.Text
+    session_state            String?
+    user                     User    @relation(fields: [userId], references: [id], onDelete: Cascade)
 
     @@unique([provider, providerAccountId])
     @@index([userId])

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -21,8 +21,8 @@ export const env = createEnv({
       process.env.VERCEL ? z.string().min(1) : z.string().url()
     ),
     // Add `.min(1) on ID and SECRET if you want to make sure they're not empty
-    DISCORD_CLIENT_ID: z.string(),
-    DISCORD_CLIENT_SECRET: z.string(),
+    GITHUB_ID: z.string(),
+    GITHUB_SECRET: z.string(),
   },
 
   /**
@@ -43,8 +43,8 @@ export const env = createEnv({
     NODE_ENV: process.env.NODE_ENV,
     NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,
-    DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
-    DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
+    GITHUB_ID: process.env.GITHUB_ID,
+    GITHUB_SECRET: process.env.GITHUB_SECRET,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation.

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -9,10 +9,7 @@ export const env = createEnv({
   server: {
     DATABASE_URL: z.string().url(),
     NODE_ENV: z.enum(["development", "test", "production"]),
-    NEXTAUTH_SECRET:
-      process.env.NODE_ENV === "production"
-        ? z.string().min(1)
-        : z.string().min(1).optional(),
+    NEXTAUTH_SECRET: z.string().min(1),
     NEXTAUTH_URL: z.preprocess(
       // This makes Vercel deployments not fail if you don't set NEXTAUTH_URL
       // Since NextAuth.js automatically uses the VERCEL_URL if present.
@@ -21,8 +18,10 @@ export const env = createEnv({
       process.env.VERCEL ? z.string().min(1) : z.string().url()
     ),
     // Add `.min(1) on ID and SECRET if you want to make sure they're not empty
-    GITHUB_ID: z.string(),
-    GITHUB_SECRET: z.string(),
+    DISCORD_CLIENT_ID: z.string().min(1),
+    DISCORD_CLIENT_SECRET: z.string().min(1),
+    GITHUB_ID: z.string().min(1),
+    GITHUB_SECRET: z.string().min(1),
   },
 
   /**
@@ -43,6 +42,8 @@ export const env = createEnv({
     NODE_ENV: process.env.NODE_ENV,
     NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,
+    DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
+    DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
     GITHUB_ID: process.env.GITHUB_ID,
     GITHUB_SECRET: process.env.GITHUB_SECRET,
   },

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -5,6 +5,7 @@ import {
   type NextAuthOptions,
   type DefaultSession,
 } from "next-auth";
+import DiscordProvider from "next-auth/providers/discord";
 import GitHubProvider from "next-auth/providers/github";
 import { env } from "~/env.mjs";
 import { prisma } from "~/server/db";
@@ -47,6 +48,10 @@ export const authOptions: NextAuthOptions = {
   },
   adapter: PrismaAdapter(prisma),
   providers: [
+    DiscordProvider({
+      clientId: env.DISCORD_CLIENT_ID,
+      clientSecret: env.DISCORD_CLIENT_SECRET
+    }),
     GitHubProvider({
       clientId: env.GITHUB_ID,
       clientSecret: env.GITHUB_SECRET,

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -5,7 +5,7 @@ import {
   type NextAuthOptions,
   type DefaultSession,
 } from "next-auth";
-import DiscordProvider from "next-auth/providers/discord";
+import GitHubProvider from "next-auth/providers/github";
 import { env } from "~/env.mjs";
 import { prisma } from "~/server/db";
 
@@ -47,9 +47,9 @@ export const authOptions: NextAuthOptions = {
   },
   adapter: PrismaAdapter(prisma),
   providers: [
-    DiscordProvider({
-      clientId: env.DISCORD_CLIENT_ID,
-      clientSecret: env.DISCORD_CLIENT_SECRET,
+    GitHubProvider({
+      clientId: env.GITHUB_ID,
+      clientSecret: env.GITHUB_SECRET,
     }),
     /**
      * ...add more providers here.


### PR DESCRIPTION
## Describe your changes

Enabled Discord and GitHub providers for sign-in. Both are automatically connected to the db schema through Next Auth's Prisma Plugins.

## Issue number and link

#2 

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [X] Will this be part of a product update? If yes, please write one phrase about this update.

